### PR TITLE
Add missing include

### DIFF
--- a/kbrdhook/player.hpp
+++ b/kbrdhook/player.hpp
@@ -38,6 +38,8 @@
 #pragma comment(lib, "shlwapi.lib")
 #include <strsafe.h>
 
+#include <array>
+
 struct Player {
   class MediaPlayerCallback : public IMFPMediaPlayerCallback {
     size_t id_;


### PR DESCRIPTION
This header apparently expects to get `<array>` transitively from some other Standard Library header which MSVC has changed since this was written. (Necessary for this to compile with VS 2022 17.1p1.)

Aside: It's weird that `example_1.cpp` implements "A rough approximation of C++20's std::jthread, because MSVC doesn't have it yet" using `std::stop_token`, which was merged in the same PR as `jthread` (https://github.com/microsoft/STL/pull/1196) that shipped in VS 2019 16.9.